### PR TITLE
Make it work with asdf (fix #7)

### DIFF
--- a/lib/ide-elixir.js
+++ b/lib/ide-elixir.js
@@ -29,11 +29,14 @@ class ElixirLanguageClient extends AutoLanguageClient {
     });
   }
 
-  startServerProcess() {
+  startServerProcess(projectPath) {
     const command = os.platform() == "win32" ? "mix.bat" : "mix";
     const elixirLsPath = path.resolve(__dirname, "../elixir-ls-release");
     const env = Object.assign({}, process.env, { ERL_LIBS: elixirLsPath });
-    return cp.spawn(command, ["elixir_ls.language_server"], { env: env });
+    return cp.spawn(command, ["elixir_ls.language_server"], {
+      env: env,
+      cwd: projectPath
+    });
   }
 
   postInitialization({ connection }) {


### PR DESCRIPTION
`asdf` makes possible to select a specific Elixir and Erlang version per project. However, `ide-elixir` currently uses the global version regardless the fact there is a `.tool-versions` in the project directory.

This pull request fixes this issue (#7) by starting the language server in the project root directory.